### PR TITLE
Feature clicking behavior

### DIFF
--- a/components/ui/character.tsx
+++ b/components/ui/character.tsx
@@ -3,8 +3,9 @@
 import React from 'react';
 import { useState } from 'react'
 import { character, reading } from '@lib/definitions';
+import Link from "next/link";
 
-export function ReadingComponent({ reading }: {reading: reading}) {
+export function ReadingComponent({ reading }: { reading: reading }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const toggleExpand = () => {
@@ -31,7 +32,7 @@ export function ReadingComponent({ reading }: {reading: reading}) {
   )
 }
 
-export default function CharacterFullInfo({ character }: {character: character}) {
+export default function CharacterFullInfo({ character }: { character: character }) {
   return (
     <div className='flex'>
       <LargeCharacter className="flex p-4 w-1/3" char={character.id} />
@@ -42,7 +43,9 @@ export default function CharacterFullInfo({ character }: {character: character})
 
 export function LargeCharacter({ char, className }: { char: string, className: string }) {
   return <div className={`items-center justify-center text-8xl ${className}`}>
-    {char}
+      <Link href={`/character/${char}`}>
+      {char}
+  </Link>
   </div>
 }
 

--- a/components/ui/character.tsx
+++ b/components/ui/character.tsx
@@ -43,9 +43,9 @@ export default function CharacterFullInfo({ character }: { character: character 
 
 export function LargeCharacter({ char, className }: { char: string, className: string }) {
   return <div className={`items-center justify-center text-8xl ${className}`}>
-      <Link href={`/character/${char}`}>
+    <Link href={`/character/${char}`}>
       {char}
-  </Link>
+    </Link>
   </div>
 }
 

--- a/components/ui/character.tsx
+++ b/components/ui/character.tsx
@@ -32,7 +32,7 @@ export function ReadingComponent({ reading }: { reading: reading }) {
   )
 }
 
-export default function CharacterFullInfo({ character }: { character: character }) {
+export function CharacterFullInfo({ character }: { character: character }) {
   return (
     <div className='flex'>
       <Link href={`/character/${character.id}`} className="items-center justify-center flex p-4 w-1/3">

--- a/components/ui/character.tsx
+++ b/components/ui/character.tsx
@@ -35,17 +35,17 @@ export function ReadingComponent({ reading }: { reading: reading }) {
 export default function CharacterFullInfo({ character }: { character: character }) {
   return (
     <div className='flex'>
-      <LargeCharacter className="flex p-4 w-1/3" char={character.id} />
+      <Link href={`/character/${character.id}`} className="items-center justify-center flex p-4 w-1/3">
+        <LargeCharacter className="" char={character.id} />
+      </Link>
       <CharacterInfo className='p-4 w-2/3' character={character} />
     </div >
   );
 }
 
 export function LargeCharacter({ char, className }: { char: string, className: string }) {
-  return <div className={`items-center justify-center text-8xl ${className}`}>
-    <Link href={`/character/${char}`}>
-      {char}
-    </Link>
+  return <div className={` text-8xl ${className}`}>
+    {char}
   </div>
 }
 

--- a/components/ui/flashcard.tsx
+++ b/components/ui/flashcard.tsx
@@ -4,24 +4,26 @@ type FlashcardProps = {
   prompt: React.ReactNode;
   answer: React.ReactNode;
   showPrompt: boolean;
-  setShowPrompt:  React.Dispatch<React.SetStateAction<boolean>>;
+  setShowPrompt: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function FlashcardComponent(
   {
-    prompt, 
-    answer, 
-    showPrompt, 
-    setShowPrompt}: FlashcardProps){
+    prompt,
+    answer,
+    showPrompt,
+    setShowPrompt }: FlashcardProps) {
 
-    const handleClick = () => {
-      setShowPrompt(!showPrompt);
-    };
-  
-    return (
-      <div onClick={handleClick} className="card w-fit">
-        <div>{showPrompt ? prompt : answer}</div>
-      </div>
-    );
+  const handleClick = () => {
+    setShowPrompt(false);
+  };
+
+  return (
+    <div onClick={handleClick} className="card w-fit">
+      <div>{showPrompt ? prompt : answer}</div>
+      {/* useful for debuging */}
+      {/* {showPrompt ? <p>Show Prompt</p> : <p>Show Answer</p>} */}
+    </div>
+  );
 
 }

--- a/src/app/character/[char]/page.tsx
+++ b/src/app/character/[char]/page.tsx
@@ -1,22 +1,22 @@
 import characters from "../../../../public/data/characterDatabase"
-import CharacterFullInfo from "@components/ui/character"
+import { CharacterFullInfo } from "@components/ui/character"
 
 export default async function Page({
-    params,
-  }: {
-    params: Promise<{ char: string }>
-  }) {
-    const char = decodeURIComponent((await params).char)
-    const character = characters.find(x => x.id === char);
+  params,
+}: {
+  params: Promise<{ char: string }>
+}) {
+  const char = decodeURIComponent((await params).char)
+  const character = characters.find(x => x.id === char);
 
-    if (!character)
-        return <div>Unable to find {char}</div>
-    else
-        return (<CharacterFullInfo character={character} />)
-  }
+  if (!character)
+    return <div>Unable to find {char}</div>
+  else
+    return (<CharacterFullInfo character={character} />)
+}
 
-  export async function generateStaticParams() {
-    return characters.map((char) => ({
-      char: char.id,
-    }))
-  }
+export async function generateStaticParams() {
+  return characters.map((char) => ({
+    char: char.id,
+  }))
+}

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -1,12 +1,12 @@
 import characters from "../../../public/data/characterDatabase";
-import CharacterFullInfo from "@components/ui/character"
+import { CharacterFullInfo } from "@components/ui/character"
 
 export default function Page() {
     return (
         <div className="flex flex-wrap gap-4">
             {characters.map(x => (
                 <div key={x.id} className="flex flex-col basis-1/4 max-w-1/4 min-w-[300px] card">
-                        <CharacterFullInfo character={x}  />                    
+                    <CharacterFullInfo character={x} />
                 </div>
             ))}
         </div>

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -1,15 +1,12 @@
 import characters from "../../../public/data/characterDatabase";
 import CharacterFullInfo from "@components/ui/character"
-import Link from "next/link";
 
 export default function Page() {
     return (
         <div className="flex flex-wrap gap-4">
             {characters.map(x => (
                 <div key={x.id} className="flex flex-col basis-1/4 max-w-1/4 min-w-[300px] card">
-                    <Link href={`./character/${x.id}`}>
                         <CharacterFullInfo character={x}  />                    
-                    </Link>
                 </div>
             ))}
         </div>

--- a/src/app/quiz/jst/page.tsx
+++ b/src/app/quiz/jst/page.tsx
@@ -14,7 +14,7 @@ function getRandomItem<T>(array: T[]): T {
 export default function QuizPage() {
   const [quizChar, setQuizChar] = useState<reading | null>(null);
   const [mounted, setMounted] = useState(false);
-  const [showPrompt, setShowPrompt] = useState<boolean>((Math.random() < 0.5));
+  const [showPrompt, setShowPrompt] = useState<boolean>(true);
 
   useEffect(() => {
     setQuizChar(getRandomItem(jstVocab));
@@ -27,14 +27,15 @@ export default function QuizPage() {
 
   const loadNewCard = () => {
     setQuizChar(getRandomItem(jstVocab)); // Load a random character
-    setShowPrompt((Math.random() < 0.5)); // Show the prompt again for the new card
+    setShowPrompt(true); // Show the prompt again for the new card
   };
 
   return (
     <div>
+
       <FlashcardComponent
         prompt={<WordComponent reading={quizChar} className="" />}
-        answer={<MeaningComponent reading={quizChar}  />}
+        answer={<MeaningComponent reading={quizChar} />}
         showPrompt={showPrompt}
         setShowPrompt={setShowPrompt}
       />

--- a/src/app/quiz/quizPage.tsx
+++ b/src/app/quiz/quizPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import FlashcardComponent from "@components/ui/flashcard";
-import { LargeCharacter, CharacterInfo } from "@components/ui/character";
+import { LargeCharacter, CharacterFullInfo } from "@components/ui/character";
 import { useEffect, useState } from "react";
 import { character } from "@lib/definitions";
 
@@ -37,7 +37,7 @@ export default function QuizPage({ filteredCharacters }: QuizPageProps) {
     <div>
       <FlashcardComponent
         prompt={<LargeCharacter char={quizChar.id} className="" />}
-        answer={<CharacterInfo character={quizChar} className="" />}
+        answer={<CharacterFullInfo character={quizChar} />}
         showPrompt={showPrompt}
         setShowPrompt={setShowPrompt}
       />


### PR DESCRIPTION
changed behavior for how clicking on various components works.

You can now click to expand the character details from the character screen, you must click the large character to navigate to it's dedicated window. 

Flashcard now only flips once to allow expanding character info on the flip; this did result in the loss of randomly chosing which side of the card to display for JST; issue added to revisit that functionality. 